### PR TITLE
[#2] 라우터 적용 테스트

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.21.3"
   },
   "devDependencies": {
     "@babel/core": "^7.23.7",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,22 @@
 import styles from "./app.module.scss";
+import { RouterProvider, createBrowserRouter } from "react-router-dom";
+
+const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <div>라우팅 테스트 '/'</div>,
+  },
+  {
+    path: "/test",
+    element: <div>라우팅 테스트 '/test'</div>,
+  },
+]);
 
 export default function App() {
-  return <div className={styles.renderTest}>app</div>;
+  return (
+    <div className={styles.renderTest}>
+      app
+      <RouterProvider router={router} />
+    </div>
+  );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1559,6 +1559,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@remix-run/router@npm:1.14.2":
+  version: 1.14.2
+  resolution: "@remix-run/router@npm:1.14.2"
+  checksum: 163d4a8ea3e25a7a7e3015f274e54b8043eddaaa92da220cad2893eb0fcbb649f617152c6d74680a4b55c0f319944ff1b362e87f814bb73be54f8d687ee730d6
+  languageName: node
+  linkType: hard
+
 "@types/body-parser@npm:*":
   version: 1.19.5
   resolution: "@types/body-parser@npm:1.19.5"
@@ -2139,6 +2146,7 @@ __metadata:
     html-webpack-plugin: "npm:^5.6.0"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
+    react-router-dom: "npm:^6.21.3"
     sass: "npm:^1.70.0"
     sass-loader: "npm:^14.0.0"
     style-loader: "npm:^3.3.4"
@@ -4966,6 +4974,30 @@ __metadata:
   peerDependencies:
     react: ^18.2.0
   checksum: 66dfc5f93e13d0674e78ef41f92ed21dfb80f9c4ac4ac25a4b51046d41d4d2186abc915b897f69d3d0ebbffe6184e7c5876f2af26bfa956f179225d921be713a
+  languageName: node
+  linkType: hard
+
+"react-router-dom@npm:^6.21.3":
+  version: 6.21.3
+  resolution: "react-router-dom@npm:6.21.3"
+  dependencies:
+    "@remix-run/router": "npm:1.14.2"
+    react-router: "npm:6.21.3"
+  peerDependencies:
+    react: ">=16.8"
+    react-dom: ">=16.8"
+  checksum: 1bea7bf17eb148461a7a99c9314e5ccc662ae00f563e29c16038e0b1b40aefb7381685f21289df07ad2295087a783c897b4e841ed12b07cd9a0829274a224231
+  languageName: node
+  linkType: hard
+
+"react-router@npm:6.21.3":
+  version: 6.21.3
+  resolution: "react-router@npm:6.21.3"
+  dependencies:
+    "@remix-run/router": "npm:1.14.2"
+  peerDependencies:
+    react: ">=16.8"
+  checksum: 66a0377a74ef2d298b9d617c02ba7a10e7e8b8be34b303068b5b5986f05e965037c51c0d45ea3a7967438f2dfde76c2c0f638cf19d3417fb408608ee9aee1668
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- react-router-dom 기능을 추가하면서, 기존 웹팩 설정의 변경 없이도 라우팅이 가능하다는 것을 확인하였습니다.
- react-dom 은 초기 프로젝트 세팅에서 미리 설정해 두었습니다.