### PR TITLE
[#55] classNames를 clsx로 마이그레이션 

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "axios": "^1.6.7",
     "classnames": "^2.5.1",
+    "clsx": "^2.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.21.3"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "axios": "^1.6.7",
-    "classnames": "^2.5.1",
     "clsx": "^2.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/pages/register/index.tsx
+++ b/src/pages/register/index.tsx
@@ -1,31 +1,33 @@
-import classNames from "classnames/bind";
-import styles from "./index.module.scss";
+import clsx from "clsx";
 import { NavLink, Outlet } from "react-router-dom";
+import styles from "./index.module.scss";
 
 /** v1 에선 사료/간식은 동일한 데이터를 받을 예정입니다. */
 export default function Registration() {
-  const cx = classNames.bind(styles);
-
   return (
     <div>
       <nav role="tablist" aria-label="Sample Tabs">
-        <ul className={cx("tabWrapper")}>
+        <ul className={clsx(styles.tabWrapper)}>
           <li role="presentation">
             <NavLink
               to="food"
               role="tab"
-              className={({ isActive }) => cx({ selected: isActive })}
+              className={({ isActive }) =>
+                clsx({ [styles.selected]: isActive })
+              }
               id="tab-food"
               aria-controls="panel-food" // 탭 버튼이 제어하는 탭 패널을 식별
             >
               상품 정보
             </NavLink>
           </li>
-          <li role="presentation" className={cx("tab")}>
+          <li role="presentation" className={clsx(styles.tab)}>
             <NavLink
               to="puppy"
               role="tab"
-              className={({ isActive }) => cx({ selected: isActive })}
+              className={({ isActive }) =>
+                clsx({ [styles.selected]: isActive })
+              }
               id="tab-puppy"
               aria-controls="panel-puppy"
             >
@@ -34,7 +36,7 @@ export default function Registration() {
           </li>
         </ul>
       </nav>
-      <article className={cx("panelArea")}>
+      <article className={clsx(styles.panelArea)}>
         <Outlet />
       </article>
     </div>

--- a/src/shared/layouts/headerLayout/index.tsx
+++ b/src/shared/layouts/headerLayout/index.tsx
@@ -1,18 +1,13 @@
-import classnames from "classnames/bind";
+import clsx from "clsx";
 import Sidebar from "@widgets/header/sidebar";
 import styles from "./index.module.scss";
-import { useSidebar } from "@contexts/sidebarContext";
-
-const cx = classnames.bind(styles);
 
 export default function HeaderLayout({ children }) {
-  const { isOpen } = useSidebar().state;
-
   return (
-    <header className={cx("area")}>
-      <ul className={cx("listWrapper")}>{children}</ul>
+    <header className={clsx(styles.area)}>
+      <ul className={clsx(styles.listWrapper)}>{children}</ul>
       <li>
-        <Sidebar className={cx({ open: isOpen })} />
+        <Sidebar />
       </li>
     </header>
   );

--- a/src/widgets/header/sidebar/index.tsx
+++ b/src/widgets/header/sidebar/index.tsx
@@ -1,13 +1,14 @@
-import classnames from "classnames/bind";
-import styles from "./index.module.scss";
+import clsx from "clsx";
 import { NavLink } from "react-router-dom";
+import styles from "./index.module.scss";
 import { useState } from "react";
 import { useSidebar } from "@contexts/sidebarContext";
 
-const cx = classnames.bind(styles);
-
-export default function Sidebar({ className }: { className?: string }) {
-  const { setIsOpen } = useSidebar().actions;
+export default function Sidebar() {
+  const {
+    actions: { setIsOpen },
+    state: { isOpen },
+  } = useSidebar();
   const [isRecordOpen, setRecordOpen] = useState(false);
   const [recordActive, setRecordActive] = useState(false);
 
@@ -22,7 +23,7 @@ export default function Sidebar({ className }: { className?: string }) {
 
   return (
     <ul
-      className={cx("sidebar", className)}
+      className={clsx(styles.sidebar, { [styles.open]: isOpen })}
       onClick={() => {
         handleToggle(false);
         setRecordActive(false);
@@ -31,7 +32,7 @@ export default function Sidebar({ className }: { className?: string }) {
       <li>
         <NavLink
           to="/about"
-          className={({ isActive }) => cx({ selected: isActive })}
+          className={({ isActive }) => clsx({ [styles.selected]: isActive })}
         >
           알리니 소개
         </NavLink>
@@ -39,7 +40,7 @@ export default function Sidebar({ className }: { className?: string }) {
       <li>
         <NavLink
           to="/food-tracker/food-treats"
-          className={({ isActive }) => cx({ selected: isActive })}
+          className={({ isActive }) => clsx({ [styles.selected]: isActive })}
         >
           사료/간식 목록
         </NavLink>
@@ -52,14 +53,14 @@ export default function Sidebar({ className }: { className?: string }) {
               toggleRecord();
             }
           }}
-          className={styles.recordButton}
+          className={clsx(styles.recordButton)}
         >
           알리니 기록
         </button>
       </li>
       {isRecordOpen && (
         <ul
-          className={cx("subList", { open: isRecordOpen })}
+          className={clsx(styles.subList, { [styles.open]: isRecordOpen })}
           onClick={(e) => {
             e.stopPropagation();
             setRecordActive(true);
@@ -69,7 +70,9 @@ export default function Sidebar({ className }: { className?: string }) {
           <li>
             <NavLink
               to="/food-tracker/today"
-              className={({ isActive }) => cx({ selected: isActive })}
+              className={({ isActive }) =>
+                clsx({ [styles.selected]: isActive })
+              }
             >
               오늘의 기록하기
             </NavLink>
@@ -77,7 +80,9 @@ export default function Sidebar({ className }: { className?: string }) {
           <li>
             <NavLink
               to="/food-tracker/report"
-              className={({ isActive }) => cx({ selected: isActive })}
+              className={({ isActive }) =>
+                clsx({ [styles.selected]: isActive })
+              }
             >
               기록 통계
             </NavLink>
@@ -87,7 +92,7 @@ export default function Sidebar({ className }: { className?: string }) {
       <li>
         <NavLink
           to="/mypage"
-          className={({ isActive }) => cx({ selected: isActive })}
+          className={({ isActive }) => clsx({ [styles.selected]: isActive })}
         >
           마이페이지
         </NavLink>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6280,7 +6280,6 @@ __metadata:
     "@types/react-dom": "npm:^18.2.18"
     axios: "npm:^1.6.7"
     babel-loader: "npm:^9.1.3"
-    classnames: "npm:^2.5.1"
     clsx: "npm:^2.1.1"
     copy-webpack-plugin: "npm:^12.0.2"
     css-loader: "npm:^6.9.1"
@@ -7065,13 +7064,6 @@ __metadata:
   version: 1.3.1
   resolution: "cjs-module-lexer@npm:1.3.1"
   checksum: 10c0/cd98fbf3c7f4272fb0ebf71d08d0c54bc75ce0e30b9d186114e15b4ba791f3d310af65a339eea2a0318599af2818cdd8886d353b43dfab94468f72987397ad16
-  languageName: node
-  linkType: hard
-
-"classnames@npm:^2.5.1":
-  version: 2.5.1
-  resolution: "classnames@npm:2.5.1"
-  checksum: 10c0/afff4f77e62cea2d79c39962980bf316bacb0d7c49e13a21adaadb9221e1c6b9d3cdb829d8bb1b23c406f4e740507f37e1dcf506f7e3b7113d17c5bab787aa69
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6281,6 +6281,7 @@ __metadata:
     axios: "npm:^1.6.7"
     babel-loader: "npm:^9.1.3"
     classnames: "npm:^2.5.1"
+    clsx: "npm:^2.1.1"
     copy-webpack-plugin: "npm:^12.0.2"
     css-loader: "npm:^6.9.1"
     file-loader: "npm:^6.2.0"
@@ -7152,6 +7153,13 @@ __metadata:
   version: 1.0.4
   resolution: "clone@npm:1.0.4"
   checksum: 10c0/2176952b3649293473999a95d7bebfc9dc96410f6cbd3d2595cf12fd401f63a4bf41a7adbfd3ab2ff09ed60cb9870c58c6acdd18b87767366fabfc163700f13b
+  languageName: node
+  linkType: hard
+
+"clsx@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "clsx@npm:2.1.1"
+  checksum: 10c0/c4c8eb865f8c82baab07e71bfa8897c73454881c4f99d6bc81585aecd7c441746c1399d08363dc096c550cceaf97bd4ce1e8854e1771e9998d9f94c4fe075839
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- 문제 사항
기존 코드에서 classNames를 clsx로 변경하면서 몇 가지 이슈가 발생했습니다.
1. `const cx = classNames.bind(styles);` 형식의 clsx.bind 문법 사용이 불가합니다.
2. `<Sidebar className={clsx({ [styles.open]: isOpen })}/>`로 전달할 경우 `undefined`가 전달됩니다.
3. `classNames.bind` 문법을 사용하여 `<Sidebar className={cx({ open: isOpen })}/>`로 전달할 경우 `open `클래스가 잘 전달되지만, 전달받은 컴포넌트에서 `<div className={clsx(className)}>`에서 `open` 클래스가 적용되지 않습니다. 반면, `<div className={clsx(styles.open)}>`로 직접 사용할 경우에는 잘 적용됩니다.

- 관련 이미지
clsx 사용
<img width="607" alt="스크린샷 2024-10-12 오후 11 52 45" src="https://github.com/user-attachments/assets/76db9fff-87a5-47fe-a1cf-14277576bd4d">

classNames 사용
<img width="584" alt="스크린샷 2024-10-12 오후 11 53 53" src="https://github.com/user-attachments/assets/ba378e8f-9a6b-4d33-898b-070baa9dd0f5">

clsx를 사용하는 상태, classNames 사용시엔 open을 props로 넘겨받아도 동작하지만 clsx 사용시엔 동작하지 않아 isOpen에 대한 상태를 직접 사용해 styles.open 클래스를 직접적으로 이용하도록 수정
<img width="510" alt="스크린샷 2024-10-12 오후 11 54 45" src="https://github.com/user-attachments/assets/23f9f94c-9df7-40a4-817c-7ee9c26cd1bf">





