### PR TITLE
[#61]  food-tracker 페이지 내의 밥그릇 기록장(Report) 탭 Calendar UI 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@fullcalendar/core": "^6.1.15",
+    "@fullcalendar/daygrid": "^6.1.15",
+    "@fullcalendar/interaction": "^6.1.15",
+    "@fullcalendar/react": "^6.1.15",
     "axios": "^1.6.7",
     "clsx": "^2.1.1",
     "react": "^18.2.0",

--- a/src/features/foodTreats/all-list/index.module.scss
+++ b/src/features/foodTreats/all-list/index.module.scss
@@ -45,6 +45,6 @@
     flex-direction: column;
     align-items: center;
     gap: 8px;
-    padding-bottom: 30px;
+    padding-bottom: 77px;
   }
 }

--- a/src/features/foodTreats/all-list/index.tsx
+++ b/src/features/foodTreats/all-list/index.tsx
@@ -31,7 +31,7 @@ export default function AllList() {
 
   useEffect(() => {
     api
-      .searchSnack(`?domain=all&query=${query}`)
+      .searchSnack(`?domain=all&query=${query || ""}`)
       .then((res) => setFoods(res))
       .catch((error) => setError(error));
   }, [api, query]);

--- a/src/pages/food-tracker/index.module.scss
+++ b/src/pages/food-tracker/index.module.scss
@@ -1,6 +1,7 @@
 .trackerArea {
   display: flex;
   justify-content: center;
-  height: calc(100% - 47px);
+  // height: calc(100% - 47px);
+  height: 100%;
   width: 100%;
 }

--- a/src/pages/food-tracker/report/index.module.scss
+++ b/src/pages/food-tracker/report/index.module.scss
@@ -1,0 +1,5 @@
+.reportArea {
+  background-color: #f3f3f4;
+  height: 100%;
+  width: 100%;
+}

--- a/src/pages/food-tracker/report/index.module.scss
+++ b/src/pages/food-tracker/report/index.module.scss
@@ -2,4 +2,6 @@
   background-color: #f3f3f4;
   height: 100%;
   width: 100%;
+  padding: 0 16px;
+  overflow: hidden;
 }

--- a/src/pages/food-tracker/report/index.tsx
+++ b/src/pages/food-tracker/report/index.tsx
@@ -1,11 +1,13 @@
 import Calendar from "@widgets/report/fullCalendar";
+import clsx from "clsx";
+import styles from "./index.module.scss";
 
 export default function Report() {
   return (
-    <>
+    <div className={clsx(styles.reportArea)}>
       <Calendar />
       <div>바 차트 및 음식 추가</div>
       <div>성분 조회 데이터</div>
-    </>
+    </div>
   );
 }

--- a/src/pages/food-tracker/report/index.tsx
+++ b/src/pages/food-tracker/report/index.tsx
@@ -1,7 +1,11 @@
+import Calendar from "@widgets/report/fullCalendar";
+
 export default function Report() {
   return (
     <>
-      <h1>Report Component</h1>
+      <Calendar />
+      <div>바 차트 및 음식 추가</div>
+      <div>성분 조회 데이터</div>
     </>
   );
 }

--- a/src/pages/food-tracker/report/index.tsx
+++ b/src/pages/food-tracker/report/index.tsx
@@ -1,11 +1,14 @@
 import Calendar from "@widgets/report/fullCalendar";
 import clsx from "clsx";
 import styles from "./index.module.scss";
+import WrapperBox from "@ui/wrapperBox";
 
 export default function Report() {
   return (
     <div className={clsx(styles.reportArea)}>
-      <Calendar />
+      <WrapperBox>
+        <Calendar />
+      </WrapperBox>
       <div>바 차트 및 음식 추가</div>
       <div>성분 조회 데이터</div>
     </div>

--- a/src/shared/assets/icons/close-calendar.svg
+++ b/src/shared/assets/icons/close-calendar.svg
@@ -1,0 +1,7 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="3" y="3.5" width="18" height="18" rx="5" stroke="#4A4C51" stroke-width="1.5"/>
+<path d="M3 8.5H21" stroke="#4A4C51" stroke-width="1.5" stroke-linejoin="round"/>
+<path d="M16.5 2L16.5 5" stroke="#4A4C51" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.5 2L7.5 5" stroke="#4A4C51" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6.5 14.5H17.5" stroke="#4A4C51" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/shared/assets/icons/open-calendar.svg
+++ b/src/shared/assets/icons/open-calendar.svg
@@ -1,0 +1,12 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="3" y="3.5" width="18" height="18" rx="5" stroke="#4A4C51" stroke-width="1.5"/>
+<path d="M3 8.5H21" stroke="#4A4C51" stroke-width="1.5" stroke-linejoin="round"/>
+<path d="M16.5 2L16.5 5" stroke="#4A4C51" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.5 2L7.5 5" stroke="#4A4C51" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6.5 12.5H7.5" stroke="#4A4C51" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.5 12.5H12.5" stroke="#4A4C51" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.5 12.5H17.5" stroke="#4A4C51" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6.5 16.5H7.5" stroke="#4A4C51" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.5 16.5H12.5" stroke="#4A4C51" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.5 16.5H17.5" stroke="#4A4C51" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/shared/ui/wrapperBox/index.module.scss
+++ b/src/shared/ui/wrapperBox/index.module.scss
@@ -1,0 +1,5 @@
+.wrapperBoxArea {
+  background-color: #fff;
+  border-radius: 12px;
+  padding: 10px;
+}

--- a/src/shared/ui/wrapperBox/index.tsx
+++ b/src/shared/ui/wrapperBox/index.tsx
@@ -1,0 +1,7 @@
+import { ReactNode } from "react";
+import clsx from "clsx";
+import styels from "./index.module.scss";
+
+export default function WrapperBox({ children }: { children: ReactNode }) {
+  return <div className={clsx(styels.wrapperBoxArea)}>{children}</div>;
+}

--- a/src/widgets/report/fullCalendar/calendar/index.tsx
+++ b/src/widgets/report/fullCalendar/calendar/index.tsx
@@ -2,21 +2,41 @@ import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import clsx from "clsx";
 import { EventInput } from "@fullcalendar/core";
+import { useEffect, useRef, useState } from "react";
 
 interface CalendarCoreProps {
   events?: EventInput[];
   className?: string;
+  isCollapsed: boolean;
 }
+
+const DAY_NAMES = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"];
 
 export default function CalendarCore({
   events = [],
   className = "",
+  isCollapsed = false,
 }: CalendarCoreProps) {
+  const calendarRef = useRef<FullCalendar>(null);
+  const [currentView, setCurrentView] = useState<
+    "dayGridWeek" | "dayGridMonth"
+  >("dayGridWeek");
+
+  useEffect(() => {
+    const newView = isCollapsed ? "dayGridWeek" : "dayGridMonth";
+
+    if (calendarRef.current) {
+      setCurrentView(newView);
+      calendarRef.current.getApi().changeView(newView);
+    }
+  }, [isCollapsed]);
+
   return (
     <div className={clsx(className)}>
       <FullCalendar
+        ref={calendarRef}
         plugins={[dayGridPlugin]}
-        initialView="dayGridMonth"
+        initialView={currentView}
         headerToolbar={{
           left: "prev",
           center: "title",
@@ -24,14 +44,31 @@ export default function CalendarCore({
         }}
         events={events}
         dayCellContent={(arg) => {
-          return (
-            <div className={"dayCell"}>
-              {arg.dayNumberText.replace("일", "")}
-            </div>
-          );
+          if (!isCollapsed) {
+            return (
+              <div className={"dayCell"}>
+                {arg.dayNumberText.replace("일", "")}
+              </div>
+            );
+          }
+          return null;
         }}
-        dayMaxEventRows={1}
-        height="auto"
+        dayHeaderContent={(arg) => {
+          if (isCollapsed) {
+            const isToday = arg.isToday;
+            return (
+              <div className="custom-day-header">
+                <div>{DAY_NAMES[arg.date.getDay()]}</div>
+                <div className={clsx("dayCell", { today: isToday })}>
+                  {arg.date.getDate()}
+                </div>
+              </div>
+            );
+          }
+          return DAY_NAMES[arg.date.getDay()];
+        }}
+        dayMaxEventRows={isCollapsed ? 0 : 1}
+        height={isCollapsed ? "200px" : "auto"}
         locale="kr"
       />
     </div>

--- a/src/widgets/report/fullCalendar/calendar/index.tsx
+++ b/src/widgets/report/fullCalendar/calendar/index.tsx
@@ -23,6 +23,16 @@ export default function CalendarCore({
           right: "next",
         }}
         events={events}
+        dayCellContent={(arg) => {
+          return (
+            <div className={"dayCell"}>
+              {arg.dayNumberText.replace("일", "")}
+            </div>
+          );
+        }}
+        dayMaxEventRows={1}
+        height="auto"
+        locale="kr"
       />
     </div>
   );

--- a/src/widgets/report/fullCalendar/calendar/index.tsx
+++ b/src/widgets/report/fullCalendar/calendar/index.tsx
@@ -24,11 +24,13 @@ export default function CalendarCore({
 
   useEffect(() => {
     const newView = isCollapsed ? "dayGridWeek" : "dayGridMonth";
+    setCurrentView(newView);
 
-    if (calendarRef.current) {
-      setCurrentView(newView);
-      calendarRef.current.getApi().changeView(newView);
-    }
+    setTimeout(() => {
+      if (calendarRef.current) {
+        calendarRef.current.getApi().changeView(newView);
+      }
+    }, 0);
   }, [isCollapsed]);
 
   return (

--- a/src/widgets/report/fullCalendar/calendar/index.tsx
+++ b/src/widgets/report/fullCalendar/calendar/index.tsx
@@ -70,7 +70,7 @@ export default function CalendarCore({
           return DAY_NAMES[arg.date.getDay()];
         }}
         dayMaxEventRows={isCollapsed ? 0 : 1}
-        height={isCollapsed ? "200px" : "auto"}
+        height={isCollapsed ? "110px" : "auto"}
         locale="kr"
       />
     </div>

--- a/src/widgets/report/fullCalendar/calendar/index.tsx
+++ b/src/widgets/report/fullCalendar/calendar/index.tsx
@@ -1,15 +1,29 @@
 import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
+import clsx from "clsx";
+import { EventInput } from "@fullcalendar/core";
 
-export default function CalendarCore() {
+interface CalendarCoreProps {
+  events?: EventInput[];
+  className?: string;
+}
+
+export default function CalendarCore({
+  events = [],
+  className = "",
+}: CalendarCoreProps) {
   return (
-    <FullCalendar
-      plugins={[dayGridPlugin]}
-      initialView="dayGridMonth"
-      events={[
-        { title: "Event 1", date: "2024-06-01" },
-        { title: "Event 2", date: "2024-06-07" },
-      ]}
-    />
+    <div className={clsx(className)}>
+      <FullCalendar
+        plugins={[dayGridPlugin]}
+        initialView="dayGridMonth"
+        headerToolbar={{
+          left: "prev",
+          center: "title",
+          right: "next",
+        }}
+        events={events}
+      />
+    </div>
   );
 }

--- a/src/widgets/report/fullCalendar/calendar/index.tsx
+++ b/src/widgets/report/fullCalendar/calendar/index.tsx
@@ -3,6 +3,7 @@ import dayGridPlugin from "@fullcalendar/daygrid";
 import clsx from "clsx";
 import { EventInput } from "@fullcalendar/core";
 import { useEffect, useRef, useState } from "react";
+import { VerboseFormattingArg } from "@fullcalendar/core/internal";
 
 interface CalendarCoreProps {
   events?: EventInput[];
@@ -32,6 +33,26 @@ export default function CalendarCore({
       }
     }, 0);
   }, [isCollapsed]);
+
+  const titleFormatter = (date: VerboseFormattingArg) => {
+    const year = date.date.year;
+    const month = date.date.month + 1; // 0부터 시작하므로 1을 더해줍니다.
+
+    // dayGridWeek일 경우
+    if (currentView === "dayGridWeek") {
+      const start = date.start; // 시작 날짜
+      const end = date.end; // 끝 날짜
+      const startDate = `${start.year}.${String(start.month + 1).padStart(
+        2,
+        "0"
+      )}.${String(start.day).padStart(2, "0")}`;
+      const endDate = `${String(end?.day).padStart(2, "0")}`;
+      return `${startDate} - ${endDate}`;
+    } else {
+      // dayGridWeek이 아닐 경우
+      return `${year}.${String(month).padStart(2, "0")}`;
+    }
+  };
 
   return (
     <div className={clsx(className)}>
@@ -72,6 +93,7 @@ export default function CalendarCore({
         dayMaxEventRows={isCollapsed ? 0 : 1}
         height={isCollapsed ? "110px" : "auto"}
         locale="kr"
+        titleFormat={titleFormatter}
       />
     </div>
   );

--- a/src/widgets/report/fullCalendar/calendar/index.tsx
+++ b/src/widgets/report/fullCalendar/calendar/index.tsx
@@ -91,7 +91,7 @@ export default function CalendarCore({
           return DAY_NAMES[arg.date.getDay()];
         }}
         dayMaxEventRows={isCollapsed ? 0 : 1}
-        height={isCollapsed ? "110px" : "auto"}
+        height={isCollapsed ? "100px" : "auto"}
         locale="kr"
         titleFormat={titleFormatter}
       />

--- a/src/widgets/report/fullCalendar/calendar/index.tsx
+++ b/src/widgets/report/fullCalendar/calendar/index.tsx
@@ -1,0 +1,15 @@
+import FullCalendar from "@fullcalendar/react";
+import dayGridPlugin from "@fullcalendar/daygrid";
+
+export default function CalendarCore() {
+  return (
+    <FullCalendar
+      plugins={[dayGridPlugin]}
+      initialView="dayGridMonth"
+      events={[
+        { title: "Event 1", date: "2024-06-01" },
+        { title: "Event 2", date: "2024-06-07" },
+      ]}
+    />
+  );
+}

--- a/src/widgets/report/fullCalendar/index.module.scss
+++ b/src/widgets/report/fullCalendar/index.module.scss
@@ -1,10 +1,34 @@
+@use "@styles/base/mixins" as *;
+
 .customCalendar {
   :global {
     .fc-header-toolbar {
       display: flex;
       justify-content: flex-start;
       align-items: center;
-      padding: 1em 0;
+    }
+
+    .fc-col-header-cell-cushion {
+      text-transform: uppercase;
+    }
+
+    .fc-day-sun .fc-col-header-cell-cushion {
+      color: #e8805f;
+    }
+
+    .fc-day-sat .fc-col-header-cell-cushion {
+      color: #639cd9;
+    }
+
+    .fc-col-header-cell:not(.fc-day-sat):not(.fc-day-sun)
+      .fc-col-header-cell-cushion {
+      color: #7b7e86;
+    }
+
+    // 숫자 셀
+    .fc-daygrid-day-number {
+      color: #393a3e;
+      font-size: 14px;
     }
 
     .fc-toolbar-chunk {
@@ -39,10 +63,125 @@
       }
     }
 
+    // 월 제목 스타일 조정
     .fc-toolbar-title {
-      font-size: 1.1rem;
-      font-weight: bold;
+      @include pretendard-semibold;
+      font-size: 1rem;
       margin: 0 8px;
     }
+
+    // 오늘날짜 표시
+    .fc-day-today {
+      background-color: transparent !important;
+
+      .fc-daygrid-day-number {
+        background-color: #00b896;
+        color: #ffffff;
+        border-radius: 50%;
+        width: 34px;
+        height: 34px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+    }
+
+    .fc-day-today:not(.fc-day-other) {
+      background-color: transparent !important;
+    }
+
+    // 테두리와 격자 선 제거
+    .fc-theme-standard td,
+    .fc-theme-standard th {
+      border: none;
+    }
+
+    .fc-theme-standard .fc-scrollgrid {
+      border: none;
+    }
+
+    // 날짜 셀 간격 조정
+    .fc-daygrid-day-frame {
+      padding: 0px;
+
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+    }
+
+    // 요일 헤더 스타일 조정
+    .fc-col-header-cell {
+      padding: 0;
+      font-size: 10px;
+    }
+
+    // 이벤트 관련 스타일 수정
+    .fc-daygrid-day-events {
+      margin: 0;
+      min-height: 0 !important;
+      padding: 0;
+      position: absolute;
+      width: 100%;
+    }
+
+    // 이벤트 박스 배경색 조정
+    .fc-event {
+    }
+
+    .fc-event-title-container {
+      display: flex;
+      align-items: center;
+    }
+
+    // 이벤트가 있는 경우에만 표시
+    .fc-event-title {
+      max-width: 55px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      padding: 0 5px;
+      font-size: 0.8em;
+    }
+
+    .fc-daygrid-event-harness {
+      margin-top: 1px;
+    }
+
+    // 이벤트 점 스타일 조정
+    .fc-daygrid-event-dot {
+      margin: 0 4px 0 0;
+    }
+
+    // 더보기(+more) 링크 스타일 조정
+    .fc-more-link {
+      font-size: 0.85em;
+      color: #666;
+      text-decoration: none;
+      margin-top: 1px;
+      display: block;
+    }
+
+    // 셀 내부 컨텐츠 정렬 (날짜와 이벤트 사이 간격 조정)
+    .fc-daygrid-day-frame {
+      min-height: 40px;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-start;
+    }
+
+    .fc-daygrid-day-events {
+      flex-grow: 1;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+    }
   }
+}
+
+.dayCell {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
 }

--- a/src/widgets/report/fullCalendar/index.module.scss
+++ b/src/widgets/report/fullCalendar/index.module.scss
@@ -6,6 +6,9 @@
       display: flex;
       justify-content: flex-start;
       align-items: center;
+      margin: 0 !important;
+      padding-left: 0.5em;
+      color: #393a3e;
     }
 
     .fc-col-header-cell-cushion {
@@ -70,26 +73,31 @@
       margin: 0 8px;
     }
 
-    // 오늘날짜 표시
-    .fc-day-today {
-      background-color: transparent !important;
+    // dayGridWeek View에서 date에 적용
+    .custom-day-header {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 6px;
+    }
 
-      .fc-daygrid-day-number {
+    .dayCell {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 34px;
+      width: 34px;
+
+      &.today {
         background-color: #00b896;
         color: #ffffff;
         border-radius: 50%;
-        width: 34px;
-        height: 34px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
       }
     }
 
-    .fc-day-today:not(.fc-day-other) {
+    .fc-day-today {
       background-color: transparent !important;
     }
-
     // 테두리와 격자 선 제거
     .fc-theme-standard td,
     .fc-theme-standard th {
@@ -112,7 +120,7 @@
 
     // 요일 헤더 스타일 조정
     .fc-col-header-cell {
-      padding: 0;
+      padding-bottom: 1.2em;
       font-size: 10px;
     }
 
@@ -177,6 +185,20 @@
       justify-content: center;
     }
   }
+
+  &.collapsed {
+    height: auto;
+    overflow: auto;
+
+    .fc-daygrid-day-frame {
+      min-height: 40px;
+    }
+
+    .fc-col-header-cell {
+      vertical-align: top;
+      padding-top: 0.5em;
+    }
+  }
 }
 
 .dayCell {
@@ -184,4 +206,29 @@
   justify-content: center;
   align-items: center;
   height: 100%;
+}
+
+// dayGridMonth View 에서의 date
+.calendarExpanded {
+  :global {
+    // 오늘날짜 표시
+    .fc-day-today:not(.fc-col-header-cell) {
+      background-color: transparent !important;
+
+      .fc-daygrid-day-number {
+        background-color: #00b896;
+        color: #ffffff;
+        border-radius: 50%;
+        width: 34px;
+        height: 34px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+    }
+
+    .fc-day-today:not(.fc-day-other) {
+      background-color: transparent !important;
+    }
+  }
 }

--- a/src/widgets/report/fullCalendar/index.module.scss
+++ b/src/widgets/report/fullCalendar/index.module.scss
@@ -183,6 +183,7 @@
       display: flex;
       flex-direction: column;
       justify-content: center;
+      margin: 0 !important;
     }
   }
 
@@ -229,6 +230,14 @@
 
     .fc-day-today:not(.fc-day-other) {
       background-color: transparent !important;
+    }
+
+    .fc-view-harness {
+      width: 100% !important;
+    }
+
+    .fc-scrollgrid-sync-table {
+      width: 100% !important;
     }
   }
 }

--- a/src/widgets/report/fullCalendar/index.module.scss
+++ b/src/widgets/report/fullCalendar/index.module.scss
@@ -7,7 +7,7 @@
       justify-content: flex-start;
       align-items: center;
       margin: 0 !important;
-      padding-left: 0.5em;
+      padding-left: 0.2em;
       color: #393a3e;
     }
 
@@ -229,6 +229,32 @@
 
     .fc-day-today:not(.fc-day-other) {
       background-color: transparent !important;
+    }
+  }
+}
+
+.calendarArea {
+  position: relative;
+
+  .toggleCalendar {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 3px 3px;
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+
+    position: absolute;
+    top: 5px;
+    right: 4%;
+
+    &:hover {
+      opacity: 0.7;
+    }
+
+    &:active {
+      opacity: 0.9;
     }
   }
 }

--- a/src/widgets/report/fullCalendar/index.module.scss
+++ b/src/widgets/report/fullCalendar/index.module.scss
@@ -1,0 +1,48 @@
+.customCalendar {
+  :global {
+    .fc-header-toolbar {
+      display: flex;
+      justify-content: flex-start;
+      align-items: center;
+      padding: 1em 0;
+    }
+
+    .fc-toolbar-chunk {
+      display: flex;
+      align-items: center;
+    }
+
+    .fc-prev-button,
+    .fc-next-button {
+      background: none;
+      border: none;
+      color: #393a3e;
+      font-size: 1rem;
+      padding: 0.5rem;
+
+      &:hover {
+        background: none;
+        color: #393a3e;
+        opacity: 0.7;
+      }
+
+      &:focus {
+        box-shadow: none;
+      }
+
+      &:active {
+        background: none !important;
+        border: none !important;
+        color: #393a3e !important;
+        opacity: 0.9;
+        box-shadow: none !important;
+      }
+    }
+
+    .fc-toolbar-title {
+      font-size: 1.1rem;
+      font-weight: bold;
+      margin: 0 8px;
+    }
+  }
+}

--- a/src/widgets/report/fullCalendar/index.tsx
+++ b/src/widgets/report/fullCalendar/index.tsx
@@ -1,6 +1,8 @@
 import CalendarCore from "./calendar";
 import clsx from "clsx";
 import styles from "./index.module.scss";
+import OpenCalendar from "@assets/icons/open-calendar.svg";
+import CloseCalendar from "@assets/icons/close-calendar.svg";
 import { useState } from "react";
 
 export default function Calendar() {
@@ -11,9 +13,9 @@ export default function Calendar() {
   };
 
   return (
-    <>
-      <button onClick={toggleCalendar}>
-        {isCollapsed ? "Expand Calendar" : "Collapse Calendar"}
+    <div className={clsx(styles.calendarArea)}>
+      <button onClick={toggleCalendar} className={clsx(styles.toggleCalendar)}>
+        {isCollapsed ? <OpenCalendar /> : <CloseCalendar />}
       </button>
       <CalendarCore
         className={clsx(styles.customCalendar, {
@@ -27,6 +29,6 @@ export default function Calendar() {
         ]}
         isCollapsed={isCollapsed}
       />
-    </>
+    </div>
   );
 }

--- a/src/widgets/report/fullCalendar/index.tsx
+++ b/src/widgets/report/fullCalendar/index.tsx
@@ -7,8 +7,9 @@ export default function Calendar() {
     <CalendarCore
       className={clsx(styles.customCalendar)}
       events={[
-        { title: "Event 1", date: "2024-06-01" },
-        { title: "Event 2", date: "2024-06-07" },
+        { title: "Test Event 1 - This is..", date: "2024-10-01" },
+        { title: "Event 2", date: "2024-10-07" },
+        { title: "Event 3", date: "2024-10-07" },
       ]}
     />
   );

--- a/src/widgets/report/fullCalendar/index.tsx
+++ b/src/widgets/report/fullCalendar/index.tsx
@@ -1,16 +1,32 @@
 import CalendarCore from "./calendar";
 import clsx from "clsx";
 import styles from "./index.module.scss";
+import { useState } from "react";
 
 export default function Calendar() {
+  const [isCollapsed, setIsCollapsed] = useState(true);
+
+  const toggleCalendar = () => {
+    setIsCollapsed((prev) => !prev);
+  };
+
   return (
-    <CalendarCore
-      className={clsx(styles.customCalendar)}
-      events={[
-        { title: "Test Event 1 - This is..", date: "2024-10-01" },
-        { title: "Event 2", date: "2024-10-07" },
-        { title: "Event 3", date: "2024-10-07" },
-      ]}
-    />
+    <>
+      <button onClick={toggleCalendar}>
+        {isCollapsed ? "Expand Calendar" : "Collapse Calendar"}
+      </button>
+      <CalendarCore
+        className={clsx(styles.customCalendar, {
+          [styles.collapsed]: isCollapsed,
+          [styles.calendarExpanded]: !isCollapsed,
+        })}
+        events={[
+          { title: "Test Event 1 - This is..", date: "2024-10-01" },
+          { title: "Event 2", date: "2024-10-07" },
+          { title: "Event 3", date: "2024-10-07" },
+        ]}
+        isCollapsed={isCollapsed}
+      />
+    </>
   );
 }

--- a/src/widgets/report/fullCalendar/index.tsx
+++ b/src/widgets/report/fullCalendar/index.tsx
@@ -1,5 +1,15 @@
 import CalendarCore from "./calendar";
+import clsx from "clsx";
+import styles from "./index.module.scss";
 
 export default function Calendar() {
-  return <CalendarCore />;
+  return (
+    <CalendarCore
+      className={clsx(styles.customCalendar)}
+      events={[
+        { title: "Event 1", date: "2024-06-01" },
+        { title: "Event 2", date: "2024-06-07" },
+      ]}
+    />
+  );
 }

--- a/src/widgets/report/fullCalendar/index.tsx
+++ b/src/widgets/report/fullCalendar/index.tsx
@@ -1,0 +1,5 @@
+import CalendarCore from "./calendar";
+
+export default function Calendar() {
+  return <CalendarCore />;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2966,6 +2966,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@fullcalendar/core@npm:^6.1.15":
+  version: 6.1.15
+  resolution: "@fullcalendar/core@npm:6.1.15"
+  dependencies:
+    preact: "npm:~10.12.1"
+  checksum: 10c0/628445dcbfcf9c5a4012cde3ba814af7b74db66c4ec71743fe9c5f5376f96d4b18922d257ad8d5ccf1211b2415d1094dd05e2f4f3324d4dbe880a94f7e5793b7
+  languageName: node
+  linkType: hard
+
+"@fullcalendar/daygrid@npm:^6.1.15":
+  version: 6.1.15
+  resolution: "@fullcalendar/daygrid@npm:6.1.15"
+  peerDependencies:
+    "@fullcalendar/core": ~6.1.15
+  checksum: 10c0/52ba7a479675aa8e2bd36ca6c00c9cc28f11539710cf7a233e8657835b29fe21954e732a23c9b7c7c345c5b6b3c08e3af24ce9125ec28478176cce1b3e7d0da4
+  languageName: node
+  linkType: hard
+
+"@fullcalendar/interaction@npm:^6.1.15":
+  version: 6.1.15
+  resolution: "@fullcalendar/interaction@npm:6.1.15"
+  peerDependencies:
+    "@fullcalendar/core": ~6.1.15
+  checksum: 10c0/f9e2542965b3d28a4eb65638a21d036d883399956781649f5442c2fb681ee59ea5fb071779be04acb88afed9278d38fc6f5758dc8a6dfa1d7b90cb6858a0115e
+  languageName: node
+  linkType: hard
+
+"@fullcalendar/react@npm:^6.1.15":
+  version: 6.1.15
+  resolution: "@fullcalendar/react@npm:6.1.15"
+  peerDependencies:
+    "@fullcalendar/core": ~6.1.15
+    react: ^16.7.0 || ^17 || ^18 || ^19
+    react-dom: ^16.7.0 || ^17 || ^18 || ^19
+  checksum: 10c0/8185159c2fa02b31012b84c19f340b835383858d04079bcfb5ccbd1967116d862dbdb863762d99c374433a5364873727fc6f9d7356b2b1d1866ae5d50819ff6e
+  languageName: node
+  linkType: hard
+
 "@inquirer/confirm@npm:^3.0.0":
   version: 3.1.20
   resolution: "@inquirer/confirm@npm:3.1.20"
@@ -6264,6 +6302,10 @@ __metadata:
     "@babel/preset-env": "npm:^7.23.8"
     "@babel/preset-react": "npm:^7.23.3"
     "@babel/preset-typescript": "npm:^7.23.3"
+    "@fullcalendar/core": "npm:^6.1.15"
+    "@fullcalendar/daygrid": "npm:^6.1.15"
+    "@fullcalendar/interaction": "npm:^6.1.15"
+    "@fullcalendar/react": "npm:^6.1.15"
     "@storybook/addon-actions": "npm:^7.6.10"
     "@storybook/addon-controls": "npm:^7.6.10"
     "@storybook/addon-essentials": "npm:^7.6.10"
@@ -11767,6 +11809,13 @@ __metadata:
     picocolors: "npm:^1.0.1"
     source-map-js: "npm:^1.2.0"
   checksum: 10c0/65ed67573e5443beaeb582282ff27a6be7c7fe3b4d9fa15761157616f2b97510cb1c335023c26220b005909f007337026d6e3ff092f25010b484ad484e80ea7f
+  languageName: node
+  linkType: hard
+
+"preact@npm:~10.12.1":
+  version: 10.12.1
+  resolution: "preact@npm:10.12.1"
+  checksum: 10c0/c77a55e897dcf298b7aa13637fed29744d3cf6c083f2832856e8551dbf27303c8b6946569736de16b05cba15c0e44ad404beb236ad9e36583a6fc5e2efad7777
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

![cal](https://github.com/user-attachments/assets/dc353b83-efee-487c-87a9-5aabcc0f4f24)

#
### **구현 사항 요약**

- FullCalendar 라이브러리 추가 및 컴포넌트 구조 설계
- FullCalendar CSS Override를 위한 Props 설정
- 달력 커스텀 UI 구현 (펼쳐진 모습 및 Open/Close 버전)
- 생명주기 메서드 내의 flushSync 관련 버그 수정
- dayGridWeek View에서의 titleFormat 설정
- 캘린더 View 타입 변경 버튼 구현
- 배경 Wrapper 적용

### **주요 사항 상세 설명**
  1. FullCalendar 라이브러리 추가 및 컴포넌트 구조 설계

     - 커스텀과 npm-trends의 다운로드수 등의 이유로 FullCalendar 라이브러리를 프로젝트에 추가


  2. 생명주기 메서드 내의 flushSync 관련 버그 수정

     - flushSync의 상태 업데이트 강제 동기화 문제를 해결
     - setTimeout을 사용하여 비동기적으로 처리하여  렌더링 사이클이 완료된 후에 실행되도록 수정


  3. dayGridWeek View에서의 titleFormat 설정

     - titleFormatter 함수를 구현하여 dayGridWeek View에서의 타이틀 포맷을 커스터마이즈
     
  4. 캘린더 View 타입 변경 버튼 구현

     - 사용자가 캘린더 뷰 타입을 변경할 수 있는 버튼을 구현했습니다.
     

<img width="1279" alt="스크린샷 2024-10-21 오후 6 59 44" src="https://github.com/user-attachments/assets/70ffec40-ed84-41a6-9c9f-91139afabede">

### **발생한 에러 상황**
생명주기 메서드 내에서 flushSync를 사용할 때 상태 업데이트의 강제 동기화로 인한 문제가 발생했습니다. 
이를 해결하기 위해 setTimeout을 사용하여 비동기적으로 처리하도록 수정했습니다.