### PR TITLE
[#69] 회원가입 UI 구현

### DIFF
--- a/src/app/app.module.scss
+++ b/src/app/app.module.scss
@@ -5,11 +5,12 @@
   background-color: #00836b;
   background-image: url("@assets/images/allini/a-bg.png");
   background-repeat: no-repeat;
-  background-size: contain;
+  background-size: cover;
   background-position: center;
   display: flex;
   justify-content: flex-end;
   min-height: 669px;
+  overflow: hidden;
 
   .wrapper {
     background-color: #fff;

--- a/src/pages/food-tracker/report/index.module.scss
+++ b/src/pages/food-tracker/report/index.module.scss
@@ -4,6 +4,8 @@
   width: 100%;
   padding: 0 16px;
   padding-top: 1px;
+  overflow-y: scroll;
+  padding-bottom: 90px;
 
   .selectorArea {
     width: fit-content;

--- a/src/pages/home/index.module.scss
+++ b/src/pages/home/index.module.scss
@@ -3,15 +3,16 @@
 .homeArea {
   position: relative;
   width: 100%;
-  height: 100%;
+  height: 100vh;
   background-color: #f3f3f4;
+  top: -53px;
+  overflow-y: scroll;
 
   .intro {
     background-image: url("@assets/images/allini/home-bg.png");
     position: absolute;
     width: 100%;
     height: 100%;
-    top: -53px;
     background-repeat: no-repeat;
     background-size: contain;
 
@@ -65,7 +66,7 @@
 
   .contentWrapper {
     position: relative; // .intro의 absolute를 대비해 새로운 쌓임 맥락 생성
-    padding-top: calc(100% * 0.75); // intro 이미지의 비율만큼 패딩 추가
+    padding-top: calc(100% * 0.85); // intro 이미지의 비율만큼 패딩 추가
     display: flex;
     flex-direction: column;
     height: 100%;

--- a/src/pages/login/index.module.scss
+++ b/src/pages/login/index.module.scss
@@ -81,6 +81,7 @@
     margin-bottom: 80px;
 
     .signupButton {
+      text-decoration: none;
       font-size: 0.75rem;
       color: #00b896;
       font-family: "Pretendard Medium";

--- a/src/pages/login/index.module.scss
+++ b/src/pages/login/index.module.scss
@@ -49,113 +49,6 @@
     align-items: center;
     margin-bottom: 48px;
     gap: 8px;
-
-    .inputContainer {
-      width: 100%;
-    }
-    .emailInput,
-    .passwordInputWrapper {
-      width: 100%;
-      height: 40px;
-      padding-left: 1em;
-      outline: none;
-      border-radius: 10px;
-      background-color: #f3f3f4;
-      border: 1px solid transparent;
-      transition: border-color 0.3s ease;
-      font-size: 14px;
-      color: #393a3e;
-    }
-    .passwordInput {
-      border: none;
-      outline: none;
-      background-color: #f3f3f4;
-      width: 100%;
-    }
-
-    .errorMessage {
-      color: #ed2f2f;
-      font-size: 0.75rem;
-      margin-top: 8px;
-      padding-left: 1em;
-    }
-
-    .errorInput {
-      border-color: #ed2f2f;
-    }
-
-    .passwordInputWrapper {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-    }
-
-    .passwordToggle {
-      border: none;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      padding-right: 9.5px;
-    }
-
-    @mixin placeholder($bg-url: "@images/etc/user.png", $error: false) {
-      background: url(if($error, "@images/etc/fail-user.png", $bg-url))
-        no-repeat 5px center;
-      color: #bebebe;
-      background-position: 0;
-      font-size: 0.875rem;
-      padding-left: 1.5em;
-    }
-
-    .emailInput::placeholder {
-      @include placeholder("@images/etc/user.png");
-    }
-
-    .emailInput.errorInput::placeholder {
-      @include placeholder("@images/etc/fail-user.png", true);
-    }
-
-    .passwordInput::placeholder {
-      @include placeholder("@images/etc/unlock.png");
-    }
-
-    .passwordInput.errorInput::placeholder {
-      @include placeholder("@images/etc/fail-unlock.png", true);
-    }
-
-    // Webkit 버전
-    .emailInput::-webkit-input-placeholder {
-      @include placeholder("@images/etc/user.png");
-    }
-
-    .emailInput.errorInput::-webkit-input-placeholder {
-      @include placeholder("@images/etc/fail-user.png", true);
-    }
-
-    .passwordInput::-webkit-input-placeholder {
-      @include placeholder("@images/etc/unlock.png");
-    }
-
-    .passwordInput.errorInput::-webkit-input-placeholder {
-      @include placeholder("@images/etc/fail-unlock.png", true);
-    }
-
-    // MS 버전
-    .emailInput:-ms-input-placeholder {
-      @include placeholder("@images/etc/user.png");
-    }
-
-    .emailInput.errorInput:-ms-input-placeholder {
-      @include placeholder("@images/etc/fail-user.png", true);
-    }
-
-    .passwordInput:-ms-input-placeholder {
-      @include placeholder("@images/etc/unlock.png");
-    }
-
-    .passwordInput.errorInput:-ms-input-placeholder {
-      @include placeholder("@images/etc/fail-unlock.png", true);
-    }
   }
 
   .loginButton {
@@ -202,6 +95,7 @@
     color: #777777;
     text-decoration: none;
   }
+
   .socialLoginWrapper {
     display: flex;
     justify-content: center;

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -5,9 +5,8 @@ import LOGO from "@images/allini/login_logo.png";
 import Google from "@assets/icons/google.svg";
 import Kakao from "@assets/icons/kakao.svg";
 import ALLINI from "@images/allini/allini_text.png";
-import Invisible from "@assets/icons/pw-invisible.svg";
-import Visible from "@assets/icons/pw-visible.svg";
 import { useApi } from "@contexts/apiContext";
+import FormInput from "@ui/formInput";
 
 interface ValidationState {
   email: {
@@ -21,7 +20,6 @@ interface ValidationState {
 }
 
 export default function Login() {
-  const [showPassword, setShowPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [validation, setValidation] = useState<ValidationState>({
     email: { isError: false, message: "앗!" },
@@ -113,10 +111,6 @@ export default function Login() {
     }
   };
 
-  const togglePasswordVisibility = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    setShowPassword(!showPassword);
-  };
   return (
     <section className={styles.loginArea}>
       <div className={styles.welcomeWrapper}>
@@ -134,51 +128,8 @@ export default function Login() {
       <div className={styles.loginForm}>
         <form onSubmit={handleSubmit}>
           <div className={styles.inputWrapper}>
-            <div className={styles.inputContainer}>
-              <input
-                className={clsx(styles.emailInput, {
-                  [styles.errorInput]: validation.email.isError,
-                })}
-                type="email"
-                name="email"
-                placeholder="이메일"
-                required
-              />
-              {validation.email.isError && (
-                <p className={styles.errorMessage}>
-                  {validation.email.message}
-                </p>
-              )}
-            </div>
-            <div className={styles.inputContainer}>
-              <div
-                className={clsx(styles.passwordInputWrapper, {
-                  [styles.errorInput]: validation.password.isError,
-                })}
-              >
-                <input
-                  className={clsx(styles.passwordInput, {
-                    [styles.errorInput]: validation.email.isError,
-                  })}
-                  type={showPassword ? "text" : "password"}
-                  name="password"
-                  placeholder="비밀번호"
-                  required
-                />
-                <button
-                  className={styles.passwordToggle}
-                  onClick={togglePasswordVisibility}
-                  type="button"
-                >
-                  {showPassword ? <Visible /> : <Invisible />}
-                </button>
-              </div>
-              {validation.password.isError && (
-                <p className={styles.errorMessage}>
-                  {validation.password.message}
-                </p>
-              )}
-            </div>
+            <FormInput.EmailInput error={validation.email} required />
+            <FormInput.PasswordInput error={validation.password} required />
           </div>
 
           <button

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -7,6 +7,7 @@ import Kakao from "@assets/icons/kakao.svg";
 import ALLINI from "@images/allini/allini_text.png";
 import { useApi } from "@contexts/apiContext";
 import FormInput from "@ui/formInput";
+import { Link } from "react-router-dom";
 
 interface ValidationState {
   email: {
@@ -143,7 +144,9 @@ export default function Login() {
           </button>
         </form>
         <div className={styles.anotherPageWrapper}>
-          <button className={styles.signupButton}>회원가입</button>
+          <Link to="/signup" className={styles.signupButton}>
+            회원가입
+          </Link>
           <p>
             {/* Link 태그 or 팝업 버튼으로 변경 예정 */}
             <a className={styles.findAccountBtn} href="/find-account">

--- a/src/pages/signup/index.module.scss
+++ b/src/pages/signup/index.module.scss
@@ -1,0 +1,41 @@
+@use "@styles/base/mixins" as *;
+
+.signupArea {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  position: relative;
+  width: 100%;
+  height: 100%;
+
+  .title {
+    color: #393a3e;
+    @include pretendard-semibold;
+    font-size: 1rem;
+  }
+
+  .signupButton {
+    width: calc(100% - 32px);
+    border-radius: 12px;
+    font-size: 0.875rem;
+    color: #ffffff;
+    padding: 0.75em 1.25em;
+    border: none;
+    background-color: #00b896;
+    transition: all 0.3s ease;
+    cursor: pointer;
+    position: absolute;
+    bottom: 16px;
+
+    &:hover {
+      background-color: darken(#00b896, 5%);
+    }
+
+    &.signupButtonDisabled {
+      background-color: #cccccc;
+      opacity: 0.7;
+      pointer-events: none;
+    }
+  }
+}

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -11,6 +11,21 @@ export default function Signup() {
         }}
         required
       />
+      <FormInput.PasswordInput
+        error={{
+          isError: true,
+          message: "",
+        }}
+        required
+      />
+      <FormInput.PasswordInput
+        error={{
+          isError: true,
+          message: "",
+        }}
+        required
+        isConfirm
+      />
     </div>
   );
 }

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,8 +1,16 @@
+import clsx from "clsx";
 import FormInput from "@ui/formInput";
+import styles from "./index.module.scss";
+import { useState } from "react";
 
 export default function Signup() {
+  const [isLoading, setIsLoading] = useState(false);
+  // TODO: 회원가입을 위한 데이터 전체가 입력됐는지 체크하는 로직 추가 및 state명 수정
+  const [singupData, setSignupData] = useState(false);
+
   return (
-    <div>
+    <div className={clsx(styles.signupArea)}>
+      <h2 className={clsx(styles.title)}>회원가입</h2>
       <FormInput.EmailInput
         error={{
           isError: true,
@@ -26,6 +34,19 @@ export default function Signup() {
         required
         isConfirm
       />
+      <button
+        className={clsx(styles.signupButton, {
+          [styles.signupButtonDisabled]: isLoading || !singupData,
+        })}
+        type="submit"
+        disabled={isLoading || !singupData}
+      >
+        {isLoading
+          ? "가입중..."
+          : !singupData
+          ? "데이터를 전부 입력해주세요"
+          : "가입하기"}
+      </button>
     </div>
   );
 }

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,3 +1,16 @@
+import FormInput from "@ui/formInput";
+
 export default function Signup() {
-  return <div>Signup</div>;
+  return (
+    <div>
+      <FormInput.EmailInput
+        error={{
+          isError: true,
+          message: "",
+          isDuplicate: true,
+        }}
+        required
+      />
+    </div>
+  );
 }

--- a/src/shared/layouts/defaultLayout/index.tsx
+++ b/src/shared/layouts/defaultLayout/index.tsx
@@ -13,7 +13,6 @@ export default function DefaultLayout() {
       <main className={styles.mainArea}>
         <Outlet />
       </main>
-      {/* <Footer /> */}
     </div>
   );
 }

--- a/src/shared/ui/formInput/emailInput/index.module.scss
+++ b/src/shared/ui/formInput/emailInput/index.module.scss
@@ -1,0 +1,65 @@
+.container {
+  width: 100%;
+
+  .input {
+    width: 100%;
+    height: 40px;
+    padding-left: 1em;
+    outline: none;
+    border-radius: 10px;
+    background-color: #f3f3f4;
+    border: 1px solid transparent;
+    transition: border-color 0.3s ease;
+    font-size: 14px;
+    color: #393a3e;
+
+    &::placeholder {
+      background: url("@images/etc/user.png") no-repeat 5px center;
+      color: #bebebe;
+      background-position: 0;
+      font-size: 0.875rem;
+      padding-left: 1.5em;
+    }
+
+    &.errorInput::placeholder {
+      background: url("@images/etc/fail-user.png") no-repeat 5px center;
+    }
+
+    // Webkit 버전
+    &::-webkit-input-placeholder {
+      background: url("@images/etc/user.png") no-repeat 5px center;
+      color: #bebebe;
+      background-position: 0;
+      font-size: 0.875rem;
+      padding-left: 1.5em;
+    }
+
+    &.errorInput::-webkit-input-placeholder {
+      background: url("@images/etc/fail-user.png") no-repeat 5px center;
+    }
+
+    // MS 버전
+    &:-ms-input-placeholder {
+      background: url("@images/etc/user.png") no-repeat 5px center;
+      color: #bebebe;
+      background-position: 0;
+      font-size: 0.875rem;
+      padding-left: 1.5em;
+    }
+
+    &.errorInput:-ms-input-placeholder {
+      background: url("@images/etc/fail-user.png") no-repeat 5px center;
+    }
+  }
+
+  .errorInput {
+    border-color: #ed2f2f;
+  }
+
+  .errorMessage {
+    color: #ed2f2f;
+    font-size: 0.75rem;
+    margin-top: 8px;
+    padding-left: 1em;
+  }
+}

--- a/src/shared/ui/formInput/emailInput/index.module.scss
+++ b/src/shared/ui/formInput/emailInput/index.module.scss
@@ -1,6 +1,24 @@
 .container {
   width: 100%;
 
+  .label {
+    display: none;
+    font-size: 14px;
+    color: #4a4c51;
+    margin-bottom: 8px;
+
+    .required {
+      color: #ed2f2f;
+      margin-left: 2px;
+    }
+  }
+
+  &.signupContainer {
+    .label {
+      display: block;
+    }
+  }
+
   .input {
     width: 100%;
     height: 40px;
@@ -25,6 +43,17 @@
       background: url("@images/etc/fail-user.png") no-repeat 5px center;
     }
 
+    &.signupInput {
+      &::placeholder {
+        background: none;
+        padding-left: 0;
+      }
+
+      &.errorInput::placeholder {
+        background: none;
+      }
+    }
+
     // Webkit 버전
     &::-webkit-input-placeholder {
       background: url("@images/etc/user.png") no-repeat 5px center;
@@ -36,6 +65,15 @@
 
     &.errorInput::-webkit-input-placeholder {
       background: url("@images/etc/fail-user.png") no-repeat 5px center;
+    }
+
+    &.signupInput::-webkit-input-placeholder {
+      background: none;
+      padding-left: 0;
+    }
+
+    &.signupInput.errorInput::-webkit-input-placeholder {
+      background: none;
     }
 
     // MS 버전
@@ -50,6 +88,15 @@
     &.errorInput:-ms-input-placeholder {
       background: url("@images/etc/fail-user.png") no-repeat 5px center;
     }
+
+    &.signupInput:-ms-input-placeholder {
+      background: none;
+      padding-left: 0;
+    }
+
+    &.signupInput.errorInput:-ms-input-placeholder {
+      background: none;
+    }
   }
 
   .errorInput {
@@ -61,5 +108,9 @@
     font-size: 0.75rem;
     margin-top: 8px;
     padding-left: 1em;
+  }
+
+  .errorLabel {
+    color: #ed2f2f;
   }
 }

--- a/src/shared/ui/formInput/emailInput/index.tsx
+++ b/src/shared/ui/formInput/emailInput/index.tsx
@@ -1,35 +1,61 @@
 import React from "react";
 import clsx from "clsx";
 import styles from "./index.module.scss";
+import { useLocation } from "react-router-dom";
 
 interface EmailInputProps {
   error?: {
     isError: boolean;
     message: string;
+    isDuplicate?: boolean;
   };
   required?: boolean;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 export default function EmailInput({
-  error = { isError: false, message: "" },
+  error = { isError: false, message: "", isDuplicate: false },
   required = false,
   onChange,
 }: EmailInputProps) {
+  const { pathname } = useLocation();
+  const isSignup = pathname === "/signup";
+
+  const getErrorMessage = () => {
+    if (isSignup && error.isDuplicate) {
+      return "중복된 이메일입니다.";
+    }
+    return error.message;
+  };
+
   return (
-    <div className={clsx(styles.container)}>
+    <div
+      className={clsx(styles.container, {
+        [styles.signupContainer]: isSignup,
+      })}
+    >
+      {isSignup && (
+        <label
+          className={clsx(styles.label, {
+            [styles.errorLabel]: error.isError,
+          })}
+        >
+          이메일 <span className={styles.required}>*</span>
+        </label>
+      )}
       <input
         className={clsx(styles.input, {
           [styles.errorInput]: error.isError,
+          [styles.signupInput]: isSignup,
         })}
         type="email"
         name="email"
-        placeholder="이메일"
+        placeholder={isSignup ? "이메일을 입력해주세요" : "이메일"}
         required={required}
         onChange={onChange}
       />
       {error.isError && (
-        <p className={clsx(styles.errorMessage)}>{error.message}</p>
+        <p className={clsx(styles.errorMessage)}>{getErrorMessage()}</p>
       )}
     </div>
   );

--- a/src/shared/ui/formInput/emailInput/index.tsx
+++ b/src/shared/ui/formInput/emailInput/index.tsx
@@ -22,10 +22,13 @@ export default function EmailInput({
   const isSignup = pathname === "/signup";
 
   const getErrorMessage = () => {
+    if (error.message) return error.message;
+
     if (isSignup && error.isDuplicate) {
       return "중복된 이메일입니다.";
     }
-    return error.message;
+
+    return "";
   };
 
   return (

--- a/src/shared/ui/formInput/emailInput/index.tsx
+++ b/src/shared/ui/formInput/emailInput/index.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import clsx from "clsx";
+import styles from "./index.module.scss";
+
+interface EmailInputProps {
+  error?: {
+    isError: boolean;
+    message: string;
+  };
+  required?: boolean;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export default function EmailInput({
+  error = { isError: false, message: "" },
+  required = false,
+  onChange,
+}: EmailInputProps) {
+  return (
+    <div className={clsx(styles.container)}>
+      <input
+        className={clsx(styles.input, {
+          [styles.errorInput]: error.isError,
+        })}
+        type="email"
+        name="email"
+        placeholder="이메일"
+        required={required}
+        onChange={onChange}
+      />
+      {error.isError && (
+        <p className={clsx(styles.errorMessage)}>{error.message}</p>
+      )}
+    </div>
+  );
+}

--- a/src/shared/ui/formInput/index.tsx
+++ b/src/shared/ui/formInput/index.tsx
@@ -1,0 +1,12 @@
+import EmailInput from "./emailInput";
+import PasswordInput from "./passwordInput";
+
+export const FormInput = Object.assign(
+  {},
+  {
+    EmailInput,
+    PasswordInput,
+  }
+);
+
+export default FormInput;

--- a/src/shared/ui/formInput/passwordInput/index.module.scss
+++ b/src/shared/ui/formInput/passwordInput/index.module.scss
@@ -1,0 +1,85 @@
+.container {
+  width: 100%;
+
+  .inputWrapper {
+    width: 100%;
+    height: 40px;
+    padding-left: 1em;
+    outline: none;
+    border-radius: 10px;
+    background-color: #f3f3f4;
+    border: 1px solid transparent;
+    transition: border-color 0.3s ease;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .input {
+    border: none;
+    outline: none;
+    background-color: #f3f3f4;
+    width: 100%;
+    font-size: 14px;
+    color: #393a3e;
+
+    &::placeholder {
+      background: url("@images/etc/unlock.png") no-repeat 5px center;
+      color: #bebebe;
+      background-position: 0;
+      font-size: 0.875rem;
+      padding-left: 1.5em;
+    }
+
+    &.errorInput::placeholder {
+      background: url("@images/etc/fail-unlock.png") no-repeat 5px center;
+    }
+
+    // Webkit 버전
+    &::-webkit-input-placeholder {
+      background: url("@images/etc/unlock.png") no-repeat 5px center;
+      color: #bebebe;
+      background-position: 0;
+      font-size: 0.875rem;
+      padding-left: 1.5em;
+    }
+
+    &.errorInput::-webkit-input-placeholder {
+      background: url("@images/etc/fail-unlock.png") no-repeat 5px center;
+    }
+
+    // MS 버전
+    &:-ms-input-placeholder {
+      background: url("@images/etc/unlock.png") no-repeat 5px center;
+      color: #bebebe;
+      background-position: 0;
+      font-size: 0.875rem;
+      padding-left: 1.5em;
+    }
+
+    &.errorInput:-ms-input-placeholder {
+      background: url("@images/etc/fail-unlock.png") no-repeat 5px center;
+    }
+  }
+
+  .errorInput {
+    border-color: #ed2f2f;
+  }
+
+  .errorMessage {
+    color: #ed2f2f;
+    font-size: 0.75rem;
+    margin-top: 8px;
+    padding-left: 1em;
+  }
+
+  .toggleButton {
+    border: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding-right: 9.5px;
+    background: transparent;
+    cursor: pointer;
+  }
+}

--- a/src/shared/ui/formInput/passwordInput/index.module.scss
+++ b/src/shared/ui/formInput/passwordInput/index.module.scss
@@ -1,6 +1,28 @@
 .container {
   width: 100%;
 
+  .label {
+    display: none;
+    font-size: 14px;
+    color: #4a4c51;
+    margin-bottom: 8px;
+
+    &.errorLabel {
+      color: #ed2f2f;
+    }
+
+    .required {
+      color: #ed2f2f;
+      margin-left: 2px;
+    }
+  }
+
+  &.signupContainer {
+    .label {
+      display: block;
+    }
+  }
+
   .inputWrapper {
     width: 100%;
     height: 40px;
@@ -13,6 +35,14 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+
+    &.signupInput {
+      border: 1px solid #e1e1e1;
+
+      &:focus-within {
+        border-color: #393a3e;
+      }
+    }
   }
 
   .input {
@@ -35,6 +65,17 @@
       background: url("@images/etc/fail-unlock.png") no-repeat 5px center;
     }
 
+    &.signupInput {
+      &::placeholder {
+        background: none;
+        padding-left: 0;
+      }
+
+      &.errorInput::placeholder {
+        background: none;
+      }
+    }
+
     // Webkit 버전
     &::-webkit-input-placeholder {
       background: url("@images/etc/unlock.png") no-repeat 5px center;
@@ -48,6 +89,15 @@
       background: url("@images/etc/fail-unlock.png") no-repeat 5px center;
     }
 
+    &.signupInput::-webkit-input-placeholder {
+      background: none;
+      padding-left: 0;
+    }
+
+    &.signupInput.errorInput::-webkit-input-placeholder {
+      background: none;
+    }
+
     // MS 버전
     &:-ms-input-placeholder {
       background: url("@images/etc/unlock.png") no-repeat 5px center;
@@ -59,6 +109,15 @@
 
     &.errorInput:-ms-input-placeholder {
       background: url("@images/etc/fail-unlock.png") no-repeat 5px center;
+    }
+
+    &.signupInput:-ms-input-placeholder {
+      background: none;
+      padding-left: 0;
+    }
+
+    &.signupInput.errorInput:-ms-input-placeholder {
+      background: none;
     }
   }
 

--- a/src/shared/ui/formInput/passwordInput/index.tsx
+++ b/src/shared/ui/formInput/passwordInput/index.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from "react";
+import clsx from "clsx";
+import Invisible from "@assets/icons/pw-invisible.svg";
+import Visible from "@assets/icons/pw-visible.svg";
+import styles from "./index.module.scss";
+
+interface PasswordInputProps {
+  error?: {
+    isError: boolean;
+    message: string;
+  };
+  required?: boolean;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export default function PasswordInput({
+  error = { isError: false, message: "" },
+  required = false,
+  onChange,
+}: PasswordInputProps) {
+  const [showPassword, setShowPassword] = useState(false);
+
+  const togglePasswordVisibility = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    setShowPassword(!showPassword);
+  };
+
+  return (
+    <div className={clsx(styles.container)}>
+      <div
+        className={clsx(styles.inputWrapper, {
+          [styles.errorInput]: error.isError,
+        })}
+      >
+        <input
+          className={clsx(styles.input, {
+            [styles.errorInput]: error.isError,
+          })}
+          type={showPassword ? "text" : "password"}
+          name="password"
+          placeholder="비밀번호"
+          required={required}
+          onChange={onChange}
+        />
+        <button
+          className={clsx(styles.toggleButton)}
+          onClick={togglePasswordVisibility}
+          type="button"
+        >
+          {showPassword ? <Visible /> : <Invisible />}
+        </button>
+      </div>
+      {error.isError && (
+        <p className={clsx(styles.errorMessage)}>{error.message}</p>
+      )}
+    </div>
+  );
+}

--- a/src/shared/ui/formInput/passwordInput/index.tsx
+++ b/src/shared/ui/formInput/passwordInput/index.tsx
@@ -3,6 +3,7 @@ import clsx from "clsx";
 import Invisible from "@assets/icons/pw-invisible.svg";
 import Visible from "@assets/icons/pw-visible.svg";
 import styles from "./index.module.scss";
+import { useLocation } from "react-router-dom";
 
 interface PasswordInputProps {
   error?: {
@@ -11,34 +12,77 @@ interface PasswordInputProps {
   };
   required?: boolean;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  isConfirm?: boolean; // 비밀번호 재확인 입력인지 여부
 }
 
 export default function PasswordInput({
   error = { isError: false, message: "" },
   required = false,
   onChange,
+  isConfirm = false,
 }: PasswordInputProps) {
   const [showPassword, setShowPassword] = useState(false);
+  const { pathname } = useLocation();
+  const isSignup = pathname === "/signup";
 
   const togglePasswordVisibility = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     setShowPassword(!showPassword);
   };
 
+  const getPlaceholder = () => {
+    if (!isSignup) return "비밀번호";
+    return isConfirm ? "비밀번호를 재입력해주세요" : "비밀번호를 입력해주세요";
+  };
+
+  const getLabel = () => {
+    return isConfirm ? "비밀번호 재확인" : "비밀번호";
+  };
+
+  const getErrorMessage = () => {
+    // error.message가 있으면 우선적으로 보여줌
+    if (error.message) return error.message;
+
+    // error.message가 없을 경우 기본 에러 메시지 표시
+    if (isSignup) {
+      return isConfirm
+        ? "위에 입력한 비밀번호와 다르게 입력했어요. 다시 한 번 확인해주세요."
+        : "영문, 숫자, 특수문자를 포함하여 8자 이상 입력해주세요.";
+    }
+
+    // 로그인 페이지의 경우 빈 문자열 반환
+    return "";
+  };
+
   return (
-    <div className={clsx(styles.container)}>
+    <div
+      className={clsx(styles.container, {
+        [styles.signupContainer]: isSignup,
+      })}
+    >
+      {isSignup && (
+        <label
+          className={clsx(styles.label, {
+            [styles.errorLabel]: error.isError,
+          })}
+        >
+          {getLabel()} <span className={styles.required}>*</span>
+        </label>
+      )}
       <div
         className={clsx(styles.inputWrapper, {
           [styles.errorInput]: error.isError,
+          [styles.signupInput]: isSignup,
         })}
       >
         <input
           className={clsx(styles.input, {
             [styles.errorInput]: error.isError,
+            [styles.signupInput]: isSignup,
           })}
           type={showPassword ? "text" : "password"}
-          name="password"
-          placeholder="비밀번호"
+          name={isConfirm ? "passwordConfirm" : "password"}
+          placeholder={getPlaceholder()}
           required={required}
           onChange={onChange}
         />
@@ -51,7 +95,7 @@ export default function PasswordInput({
         </button>
       </div>
       {error.isError && (
-        <p className={clsx(styles.errorMessage)}>{error.message}</p>
+        <p className={clsx(styles.errorMessage)}>{getErrorMessage()}</p>
       )}
     </div>
   );

--- a/src/widgets/report/fullCalendar/index.module.scss
+++ b/src/widgets/report/fullCalendar/index.module.scss
@@ -189,7 +189,7 @@
 
   &.collapsed {
     height: auto;
-    overflow: auto;
+    overflow: hidden;
 
     .fc-daygrid-day-frame {
       min-height: 40px;


### PR DESCRIPTION
- Login 페이지에서 사용된 input UI의 재활용을 위해 별도 컴포넌트로 분리
- 이메일 중복 버튼, 이메일 인증은 v2에서 구현 예정

### **관련 이슈**
- #67 

![스크린샷 2024-10-29 오후 9 25 07](https://github.com/user-attachments/assets/fd30f8e4-e3de-4d0a-8fb5-ef4548f92f23)
